### PR TITLE
ci: Added CI/CD pipelines to continuously build and push Tiddlywiki container

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -5,8 +5,8 @@
 
 name: "CD: Publish tiddlywiki-docker to GHCR"
 on:
-  push: {}
-    #branches: [main]
+  push:
+    branches: [main]
 jobs:
   build-push:
     name: "Build & Push tiddlywiki-docker"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,23 @@
+#
+# tiddlywiki-docker
+# cd pipeline to build and publish container
+# 
+
+name: "CD: Publish tiddlywiki-docker to GHCR"
+on:
+  push: {}
+    #branches: [main]
+jobs:
+  build-push:
+    name: "Build & Push tiddlywiki-docker"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Build tiddlywiki-docker"
+        run: make
+      - name: "Authenticate with GHCR"
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: "Publish image to GHCR (latest)"
+        run: make push-latest
+      - name: "Publish image to GHCR (versioned)"
+        run: make push

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Build tiddlywiki-docker"
-        run: make ghcr.io/mrzzy/tiddlywiki-docker
+        run: make ghcr.io/mrzzy/tiddlywiki

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,8 @@
 
 name: "CD: Publish tiddlywiki-docker to GHCR"
 on:
-  push:
-    branches: [main]
+  push: {}
+    #branches: [main]
 jobs:
   build-push:
     name: "Build & Push tiddlywiki-docker"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,15 @@ jobs:
   build-push:
     name: "Build & Push tiddlywiki-docker"
     runs-on: ubuntu-20.04
+    env:
+      IMAGE_VERSION: latest
     steps:
       - uses: actions/checkout@v2
       - name: "Build tiddlywiki-docker"
-        run: make ghcr.io/mrzzy/tiddlywiki
+        run: make
       - name: "Authenticate with GHCR"
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: "Publish image to GHCR (latest)"
+        run: make push-latest
+      - name: "Publish image to GHCR (versioned)"
+        run: make push

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,17 @@
+#
+# tiddlywiki-docker
+# cd pipeline to push container to github container registery
+# 
+
+name: "CD: Publish tiddlywiki-docker to GHCR"
+on:
+  push:
+    branches: [main]
+jobs:
+  build-push:
+    name: "Build & Push tiddlywiki-docker"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Build tiddlywiki-docker"
+        run: make ghcr.io/mrzzy/tiddlywiki-docker

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,25 +1,16 @@
 #
 # tiddlywiki-docker
-# cd pipeline to push container to github container registery
+# ci pipeline to ensure that the container builds
 # 
 
-name: "CD: Publish tiddlywiki-docker to GHCR"
+name: "CI: Build tiddlywiki-docker"
 on:
   push: {}
-    #branches: [main]
 jobs:
-  build-push:
-    name: "Build & Push tiddlywiki-docker"
+  build:
+    name: "Build tiddlywiki-docker"
     runs-on: ubuntu-20.04
-    env:
-      IMAGE_VERSION: latest
     steps:
       - uses: actions/checkout@v2
       - name: "Build tiddlywiki-docker"
         run: make
-      - name: "Authenticate with GHCR"
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: "Publish image to GHCR (latest)"
-        run: make push-latest
-      - name: "Publish image to GHCR (versioned)"
-        run: make push

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,3 +15,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: "Build tiddlywiki-docker"
         run: make ghcr.io/mrzzy/tiddlywiki
+      - name: "Authenticate with GHCR"
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,7 @@ COPY plugins /plugins
 COPY themes /themes
 
 # define plugin, themes search path
-ENV TIDDLYWIKI_PLUGIN_PATH="/plugins:/themes"
-ENV TIDDLYWIKI_THEME_PATH="/themes"
+ENV TIDDLYWIKI_PLUGIN_PATH="/plugins:/themes" TIDDLYWIKI_THEME_PATH="/themes"
 
 # copy entrypoint script
 COPY entrypoint.sh .

--- a/makefile
+++ b/makefile
@@ -5,21 +5,28 @@
 
 
 TIDDLYWIKI_VERSION?=5.1.22
-IMAGE_VERSION?=0.0.1
+IMAGE_VERSION?=latest
 DOCKER_USER:=mrzzy
 DOCKER_REPO:=ghcr.io
 IMAGE:=$(DOCKER_REPO)/$(DOCKER_USER)/tiddlywiki
 IMAGE_TAG:=$(TIDDLYWIKI_VERSION)-$(IMAGE_VERSION)
 
-.PHONY: $(IMAGE) run
+.PHONY: $(IMAGE) run push push-latest
 .DEFAULT: $(IMAGE)
 
 $(IMAGE): Dockerfile entrypoint.sh
 	docker build --build-arg TIDDLYWIKI_VERSION=$(TIDDLYWIKI_VERSION) \
 		-f $< -t $(IMAGE):$(IMAGE_TAG) .
+	docker tag $(IMAGE):$(IMAGE_TAG) $(IMAGE):latest
 
 run:
 	docker run -it --init \
 		-p 8080:8080  \
 		-v $(shell pwd)/wiki:/wiki \
 		$(IMAGE):$(IMAGE_TAG)
+
+push:
+	docker push $(IMAGE):$(IMAGE_TAG)
+
+push-latest:
+	docker push $(IMAGE):latest


### PR DESCRIPTION
Added CI/CD pipelines to continuously build and push Tiddlywiki container:
- CI pipeline continuously builds  Tiddlywiki container on every push.
- CD pipeline publishes Tiddlywiki container on pushes to `main` branch.
- added a project makefile to encapsulate some convenience project tasks. 