### PR TITLE
ci: Update CI to tag container with version derived from git describe

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -5,8 +5,7 @@
 
 name: "CD: Publish tiddlywiki-docker to GHCR"
 on:
-  push:
-    branches: [main]
+  push: {}
 jobs:
   build-push:
     name: "Build & Push tiddlywiki-docker"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -15,23 +15,14 @@ jobs:
         with:
           # required to retrieve all tags
           fetch-depth: '0'
-      - name: "Get image version"
-        id: get-version
-        run: |
-          IMAGE_VERSION=$(git describe | tr -d "v")
-          echo "::set-output name=version::$IMAGE_VERSION"
+      - name: "Get version from tag and set IMAGE_VERSION env var"
+        run: echo "IMAGE_VERSION=$(git describe | tr -d 'v')" >> $GITHUB_ENV
       - name: "Build tiddlywiki-docker"
-        env:
-          IMAGE_VERSION: ${{ steps.get-version.version }}
         run: |
           make
       - name: "Authenticate with GHCR"
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: "Publish image to GHCR (latest)"
-        env:
-          IMAGE_VERSION: ${{ steps.get-version.version }}
         run: make push-latest
-      - name: "Publish image to GHCR (version: ${{ steps.get-version.version }})"
-        env:
-          IMAGE_VERSION: ${{ steps.get-version.version }}
+      - name: "Publish image to GHCR (version: ${{ env.IMAGE_VERSION }})"
         run: make push

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,7 +1,7 @@
 #
 # tiddlywiki-docker
 # cd pipeline to build and publish container
-# 
+#
 
 name: "CD: Publish tiddlywiki-docker to GHCR"
 on:
@@ -13,11 +13,26 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          # required to retrieve all tags
+          fetch-depth: '0'
+      - name: "Get image version"
+        id: get-version
+        run: |
+          IMAGE_VERSION=$(git describe | tr -d "v")
+          echo "::set-output name=version::$IMAGE_VERSION"
       - name: "Build tiddlywiki-docker"
-        run: make
+        env:
+          IMAGE_VERSION: ${{ steps.get-version.version }}
+        run: |
+          make
       - name: "Authenticate with GHCR"
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: "Publish image to GHCR (latest)"
+        env:
+          IMAGE_VERSION: ${{ steps.get-version.version }}
         run: make push-latest
-      - name: "Publish image to GHCR (versioned)"
+      - name: "Publish image to GHCR (version: ${{ steps.get-version.version }})"
+        env:
+          IMAGE_VERSION: ${{ steps.get-version.version }}
         run: make push


### PR DESCRIPTION
Update CI to tag container with version derived from git describe:
- use `git describe` to derive version from git tags.
- use derived version to tag & push tiddlywiki-docker container.